### PR TITLE
Converting symphony response to illuminate response.

### DIFF
--- a/src/IlluminateCorsService.php
+++ b/src/IlluminateCorsService.php
@@ -1,0 +1,42 @@
+<?php namespace Barryvdh\Cors;
+
+use Asm89\Stack\CorsService;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Http\Response as IlluminateResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class IlluminateCorsService extends CorsService
+{
+    /** @var ResponseFactory $responseFactory */
+    protected $responseFactory;
+
+    public function __construct(ResponseFactory $responseFactory, array $options = array())
+    {
+        parent::__construct($options);
+        $this->responseFactory = $responseFactory;
+    }
+
+    public function handlePreflightRequest(Request $request)
+    {
+        $result = parent::handlePreflightRequest($request);
+        if ($result instanceof SymfonyResponse) {
+            $result = $this->convertResponse($result);
+        }
+        return $result;
+    }
+
+    /**
+     * Converts symfony response to illuminate response.
+     * @param SymfonyResponse $response Response returned by extended CORS service.
+     * @return IlluminateResponse Illuminate response.
+     */
+    private function convertResponse(SymfonyResponse $response)
+    {
+        return $this->responseFactory->make(
+            $response->getContent(),
+            $response->getStatusCode(),
+            $response->headers->all()
+        );
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,7 +34,9 @@ class ServiceProvider extends BaseServiceProvider
                 }
             }
 
-            return new CorsService($options);
+            return $app->makeWith(IlluminateCorsService::class, [
+                    'options' => $options,
+                ]);
         });
     }
 


### PR DESCRIPTION
I'm having issues with this package because it returns symphony responses while some of my code requires illuminate responses.
In this PR I extended the CorsService and convert responses where needed (there is only one place) with the response factory.
The service provider ensures the extended implementation gets used.