### PR TITLE
[1.0] Fixed minimum symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^7.1.3",
         "illuminate/support": "^5.8|^6.0|^7.0",
-        "symfony/http-foundation": "^4.2.12|^5",
-        "symfony/http-kernel": "^4.2.12|^5.0",
+        "symfony/http-foundation": "~4.2.12|^4.3.8|^5",
+        "symfony/http-kernel": "~4.2.12|^4.3.8|^5.0",
         "asm89/stack-cors": "^1.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1.3",
         "illuminate/support": "^5.8|^6.0|^7.0",
-        "symfony/http-foundation": "~4.2.12|^4.3.8|^5",
+        "symfony/http-foundation": "~4.2.12|^4.3.8|^5.0",
         "symfony/http-kernel": "~4.2.12|^4.3.8|^5.0",
         "asm89/stack-cors": "^1.2"
     },


### PR DESCRIPTION
Symfony 4.2.12 was chosen as the minimum version because of the security fixes in it, but older versions of 4.3.x are allowed that don't include this fix. We should probably match up the minimum versions so that all resolvable versions have the fix. That is: 4.2.12+, 4.3.8+, 4.4.0+, 5.0.0+.