### PR TITLE
global config load

### DIFF
--- a/src/HandleCors.php
+++ b/src/HandleCors.php
@@ -5,7 +5,6 @@ namespace Fruitcake\Cors;
 use Closure;
 use Asm89\Stack\CorsService;
 use Illuminate\Http\Request;
-use Illuminate\Config\Repository;
 use Symfony\Component\HttpFoundation\Response;
 
 class HandleCors
@@ -13,13 +12,9 @@ class HandleCors
     /** @var CorsService $cors */
     protected $cors;
 
-    /** @var \Illuminate\Contracts\Config\Repository */
-    protected $config;
-
-    public function __construct(CorsService $cors, Repository $config)
+    public function __construct(CorsService $cors)
     {
         $this->cors = $cors;
-        $this->config = $config;
     }
 
     /**
@@ -78,7 +73,7 @@ class HandleCors
     protected function isMatchingPath(Request $request): bool
     {
         // Get the paths from the config or the middleware
-        $paths = $this->config->get('cors.paths', []);
+        $paths = app('config')->get('cors.paths', []);
 
         foreach ($paths as $path) {
             if ($path !== '/') {


### PR DESCRIPTION
As issued by [this issue](https://github.com/fruitcake/laravel-cors/issues/282) (and some issues which encounters 405 Method Not Allowed), the config was not loaded due configuration load mechanism. An alternative solution is to use `app('config')` instead using `Illuminate/Config/Repository`. Test being carried in Lumen 6.x with results show that this approach could load the configuration.

Using alternative `app('config')` to read config instead `Illuminate/Config/Repository`