### PR TITLE
Remove dependency on global Laravel helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": ">=7",
         "illuminate/support": "^5.5|^6.0|^7.0",
+        "illuminate/contracts": "^5.5|^6.0|^7.0",
         "symfony/http-foundation": "^3.3|^4|^5.0",
         "symfony/http-kernel": "^3.3|^4|^5.0",
         "asm89/stack-cors": "^1.3"
@@ -43,7 +44,7 @@
         },
         "laravel": {
             "providers": [
-                "Fruitcake\\Cors\\CorsServiceProvider"
+              "Fruitcake\\Cors\\CorsServiceProvider"
             ]
         }
     },

--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -39,7 +39,7 @@ class CorsServiceProvider extends BaseServiceProvider
                 }
             }
 
-            return new CorsService($options);
+            return new CorsService($options, $app);
         });
     }
 

--- a/src/HandleCors.php
+++ b/src/HandleCors.php
@@ -5,6 +5,7 @@ namespace Fruitcake\Cors;
 use Closure;
 use Asm89\Stack\CorsService;
 use Illuminate\Http\Request;
+use Illuminate\Contracts\Container\Container;
 use Symfony\Component\HttpFoundation\Response;
 
 class HandleCors
@@ -12,9 +13,13 @@ class HandleCors
     /** @var CorsService $cors */
     protected $cors;
 
-    public function __construct(CorsService $cors)
+    /** @var \Illuminate\Contracts\Container\Container $container */
+    protected $container;
+    
+    public function __construct(CorsService $cors, Container $container)
     {
         $this->cors = $cors;
+        $this->container = $container;
     }
 
     /**
@@ -73,7 +78,7 @@ class HandleCors
     protected function isMatchingPath(Request $request): bool
     {
         // Get the paths from the config or the middleware
-        $paths = app('config')->get('cors.paths', []);
+        $paths = $this->container['config']->get('cors.paths', []);
 
         foreach ($paths as $path) {
             if ($path !== '/') {


### PR DESCRIPTION
First off, I realize that this package is meant to be used with Laravel or Lumen, and that the issue I'm trying to solve here doesn't appear if you use either.

At the moment, this middleware is dependent on being used in context of a Laravel / Lumen application, but doesn't explicitly state this in its dependencies. This small changes enables people using individual `illuminate` packages to also benefit from this package.

For context, I'm currently working on migrating a legacy codebase to a more modern approach, and one of the things we're using to make the process easier is the `http`, `routing` and `container` packages in the `illuminate` namespace. I could obviously just make a globally available app function and make it return the container, but this seems like a neater and more correct solution.