### PR TITLE
Allow Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
     ],
     "require": {
         "php": ">=7",
-        "illuminate/support": "^5.5|^6.0|^7.0",
-        "illuminate/contracts": "^5.5|^6.0|^7.0",
-        "symfony/http-foundation": "^3.3|^4|^5.0",
-        "symfony/http-kernel": "^3.3|^4|^5.0",
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^5.5|^6.0|^7.0|^8.0",
+        "symfony/http-foundation": "^3.3|^4.0|^5.0",
+        "symfony/http-kernel": "^3.3|^4.0|^5.0",
         "asm89/stack-cors": "^1.3"
     },
     "require-dev": {
-        "laravel/framework": "^5.5|^6.0|^7.0",
+        "laravel/framework": "^5.5|^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^6.0|^7.0|^8.0",
-        "orchestra/testbench": "^3.5|^4.0|^5.0",
+        "orchestra/testbench": "^3.5|^4.0|^5.0|^6.0",
         "squizlabs/php_codesniffer": "^3.5",
         "phpro/grumphp": "^0.16|^0.17"
     },


### PR DESCRIPTION
`laravel/laravel`'s `develop` branch will become Laravel 8 in March. We'd like to continue requiring this package, when that happens.