### PR TITLE
Validate config on resolve

### DIFF
--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -21,6 +21,20 @@ class CorsServiceProvider extends BaseServiceProvider
         $this->app->singleton(CorsService::class, function ($app) {
             $config = $app['config']->get('cors');
 
+            if ($config['exposed_headers'] && !is_array($config['exposed_headers'])) {
+                throw new \RuntimeException('CORS config `exposed_headers` should be `false` or an array');
+            }
+
+            foreach (['allowed_origins', 'allowed_origins_patterns',  'allowed_headers', 'allowed_methods'] as $key) {
+                if (!is_array($config[$key])) {
+                    throw new \RuntimeException('CORS config `' . $key . '` should be an array');
+                }
+            }
+
+            if ($config['max_age'] !== false && !is_numeric($config['max_age'])) {
+                throw new \RuntimeException('CORS config `max_age` should be an integer or `false`');
+            }
+
             // Convert case to supported options
             $options = [
                 'supportsCredentials' => $config['supports_credentials'],

--- a/tests/GlobalMiddlewareTest.php
+++ b/tests/GlobalMiddlewareTest.php
@@ -173,7 +173,6 @@ class GlobalMiddlewareTest extends TestCase
     public function testInvalidExposedHeadersException()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectDeprecationMessage('exposed_headers');
 
         $this->app['config']->set('cors.exposed_headers', true);
 
@@ -185,7 +184,6 @@ class GlobalMiddlewareTest extends TestCase
     public function testInvalidOriginsException()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectDeprecationMessage('allowed_origins');
 
         $this->app['config']->set('cors.allowed_origins', true);
 
@@ -197,7 +195,7 @@ class GlobalMiddlewareTest extends TestCase
     public function testInvalidMaxAgeException()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectDeprecationMessage('max_age');
+        
         $this->app['config']->set('cors.max_age', true);
 
         $this->call('POST', 'api/validation', [], [], [], [

--- a/tests/GlobalMiddlewareTest.php
+++ b/tests/GlobalMiddlewareTest.php
@@ -44,6 +44,45 @@ class GlobalMiddlewareTest extends TestCase
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
+    public function testAllowAllOrigins()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'laravel.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testAllowAllOriginsWildcard()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'test.laravel.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testAllowAllOriginsWildcardNoMatch()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'test.symfony.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(403, $crawler->getStatusCode());
+    }
+
     public function testOptionsAllowOriginAllowedNonExistingRoute()
     {
         $crawler = $this->call('OPTIONS', 'api/pang', [], [], [], [
@@ -129,5 +168,40 @@ class GlobalMiddlewareTest extends TestCase
         ]);
         $this->assertEquals('localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(302, $crawler->getStatusCode());
+    }
+
+    public function testInvalidExposedHeadersException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectDeprecationMessage('exposed_headers');
+
+        $this->app['config']->set('cors.exposed_headers', true);
+
+        $this->call('POST', 'api/validation', [], [], [], [
+            'HTTP_ORIGIN' => 'localhost',
+        ]);
+    }
+
+    public function testInvalidOriginsException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectDeprecationMessage('allowed_origins');
+
+        $this->app['config']->set('cors.allowed_origins', true);
+
+        $this->call('POST', 'api/validation', [], [], [], [
+            'HTTP_ORIGIN' => 'localhost',
+        ]);
+    }
+
+    public function testInvalidMaxAgeException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectDeprecationMessage('max_age');
+        $this->app['config']->set('cors.max_age', true);
+
+        $this->call('POST', 'api/validation', [], [], [], [
+            'HTTP_ORIGIN' => 'localhost',
+        ]);
     }
 }


### PR DESCRIPTION
Make sure the config is valid when we resolve the CorsService, to prevent errors on the actual CORS requests (which are then swallowed)