### PR TITLE
Test prependmiddleware

### DIFF
--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -152,15 +152,28 @@ class BrowserTest extends \Orchestra\Testbench\Dusk\TestCase
             $kernel->pushMiddleware(ProtectedMiddleware::class);
         });
 
-        File::delete(__DIR__ .'/Browser/invalid.flag');
+        $this->browse(function ($browser) {
+            $browser->visit('js/middleware.html')
+                ->waitForText('passes: 2')
+                ->assertSee('passes: 2');
+        });
+    }
+
+
+    public function testPrependMiddleware()
+    {
+        $this->tweakApplication(function ($app) {
+            // Add the middleware
+            /** @var Kernel $kernel */
+            $kernel = $app->make(Kernel::class);
+            $kernel->prependMiddleware(ProtectedMiddleware::class);
+        });
 
         $this->browse(function ($browser) {
             $browser->visit('js/middleware.html')
                 ->waitForText('passes: 2')
                 ->assertSee('passes: 2');
         });
-
-        $this->assertFalse(File::exists(__DIR__ .'/Browser/invalid.flag'));
     }
 
     public function testFetchInvalid()

--- a/tests/js/test.middleware.js
+++ b/tests/js/test.middleware.js
@@ -4,7 +4,7 @@
   CORS_SERVER = 'localhost:9292';
 
   describe('CORS-INVALID', function() {
-    return it('should allow access to invalid auth resource', function(done) {
+    it('should allow access to invalid auth resource', function(done) {
       return fetch(`http://${CORS_SERVER}/protected`, {
         method: 'GET',
         mode: 'cors'
@@ -12,6 +12,19 @@
         expect(response.status).to.eql(401);
         return done();
       })
+    });
+
+    return it('should allow preflighted resource', function(done) {
+      const headers = new Headers();
+      headers.append('X-Requested-With', 'XMLHTTPRequest');
+      return fetch(`http://${CORS_SERVER}/protected`, {
+        method: 'PUT',
+        mode: 'cors',
+        headers: headers
+      }).then((response) => {
+        expect(response.status).to.eql(401);
+        return done();
+      });
     });
   });
 


### PR DESCRIPTION
So when the middleware returns a response, the $next() is never called, so Cors never reached. Not sure if this is preventable with Middleware at all, or we should only listen to the dispatched event (or something else). Terminable middleware would be too late.