### PR TITLE
Update wildcard comments in config file

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -12,7 +12,7 @@ return [
     | You don't need to provide both allowed_origins and allowed_origins_patterns.
     | If one of the strings passed matches, it is considered a valid origin.
     |
-    | If array('*') is provided to allowed_methods, allowed_origins or allowed_headers
+    | If ['*'] is provided to allowed_methods, allowed_origins or allowed_headers
     | all methods / origins / headers are allowed.
     |
     */
@@ -24,12 +24,12 @@ return [
     'paths' => [],
 
     /*
-    * Matches the request method. `[*]` allows all methods.
+    * Matches the request method. `['*']` allows all methods.
     */
     'allowed_methods' => ['*'],
 
     /*
-     * Matches the request origin. `[*]` allows all origins. Wildcards can be used, eg `*.mydomain.com`
+     * Matches the request origin. `['*']` allows all origins. Wildcards can be used, eg `*.mydomain.com`
      */
     'allowed_origins' => ['*'],
 
@@ -39,7 +39,7 @@ return [
     'allowed_origins_patterns' => [],
 
     /*
-     * Sets the Access-Control-Allow-Headers response header. `[*]` allows all headers.
+     * Sets the Access-Control-Allow-Headers response header. `['*']` allows all headers.
      */
     'allowed_headers' => ['*'],
 


### PR DESCRIPTION
The current comments for wildcard settings seem to be missing quotation marks for the string value.

If this was intentional, just ignore my PR.