### PR TITLE
Update docs & tests to reflect Origin header always contains scheme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ protected $middleware = [
 
 Now update the config to define the paths you want to run the CORS service on, (see Configuration below):
 
-```php 
+```php
 'paths' => ['api/*'],
 ```
 
@@ -74,7 +74,7 @@ php artisan vendor:publish --tag="cors"
 | Option                   | Description                                                              | Default value |
 |--------------------------|--------------------------------------------------------------------------|---------------|
 | paths                    | You can enable CORS for 1 or multiple paths, eg. `['api/*'] `            | `array()`     |
-| allowed_origins          | Matches the request origin. Wildcards can be used, eg `*.mydomain.com`   | `array('*')`  |
+| allowed_origins          | Matches the request origin. Wildcards can be used, eg. `*.mydomain.com`  | `array('*')`  |
 | allowed_origins_patterns | Matches the request origin with `preg_match`.                            | `array()`     |
 | allowed_methods          | Matches the request method.                                              | `array('*')`  |
 | allowed_headers          | Sets the Access-Control-Allow-Headers response header.                   | `array('*')`  |
@@ -84,6 +84,8 @@ php artisan vendor:publish --tag="cors"
 
 
 `allowed_origins`, `allowed_headers` and `allowed_methods` can be set to `['*']` to accept any value.
+
+> **Note:** For `allowed_origins` you must include the scheme when not using a wildcard, eg. `['http://example.com', 'https://example.com']`. You must also take into account that the scheme will be present when using `allowed_origins_patterns`.
 
 > **Note:** Try to be a specific as possible. You can start developing with loose constraints, but it's better to be as strict as possible!
 
@@ -126,7 +128,7 @@ If you `echo()`, `dd()`, `die()`, `exit()`, `dump()` etc in your code, you will 
 
 ### Disabling CSRF protection for your API
 
-If possible, use a different route group with CSRF protection enabled. 
+If possible, use a different route group with CSRF protection enabled.
 Otherwise you can disable CSRF for certain requests in `App\Http\Middleware\VerifyCsrfToken`:
 
 ```php
@@ -135,7 +137,7 @@ protected $except = [
 ];
 ```
 
-    
+
 ## License
 
 Released under the MIT License, see [LICENSE](LICENSE).

--- a/tests/GlobalMiddlewareTest.php
+++ b/tests/GlobalMiddlewareTest.php
@@ -29,18 +29,18 @@ class GlobalMiddlewareTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
     public function testOptionsAllowOriginAllowed()
     {
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -49,7 +49,7 @@ class GlobalMiddlewareTest extends TestCase
         $this->app['config']->set('cors.allowed_origins', ['*']);
 
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'laravel.com',
+            'HTTP_ORIGIN' => 'http://laravel.com',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
@@ -62,11 +62,11 @@ class GlobalMiddlewareTest extends TestCase
         $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
 
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'test.laravel.com',
+            'HTTP_ORIGIN' => 'http://test.laravel.com',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -75,7 +75,7 @@ class GlobalMiddlewareTest extends TestCase
         $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
 
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'test.symfony.com',
+            'HTTP_ORIGIN' => 'http://test.symfony.com',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
@@ -85,28 +85,28 @@ class GlobalMiddlewareTest extends TestCase
     public function testOptionsAllowOriginAllowedNonExistingRoute()
     {
         $crawler = $this->call('OPTIONS', 'api/pang', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
     public function testOptionsAllowOriginNotAllowed()
     {
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'otherhost',
+            'HTTP_ORIGIN' => 'http://otherhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
     }
 
     public function testAllowMethodAllowed()
     {
         $crawler = $this->call('POST', 'web/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Methods'));
@@ -118,7 +118,7 @@ class GlobalMiddlewareTest extends TestCase
     public function testAllowMethodNotAllowed()
     {
         $crawler = $this->call('POST', 'web/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'PUT',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Methods'));
@@ -128,7 +128,7 @@ class GlobalMiddlewareTest extends TestCase
     public function testAllowHeaderAllowedOptions()
     {
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-1, x-custom-2',
         ]);
@@ -143,7 +143,7 @@ class GlobalMiddlewareTest extends TestCase
         $this->app['config']->set('cors.allowed_headers', ['*']);
 
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
@@ -156,7 +156,7 @@ class GlobalMiddlewareTest extends TestCase
     public function testAllowHeaderNotAllowedOptions()
     {
         $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
@@ -166,7 +166,7 @@ class GlobalMiddlewareTest extends TestCase
     public function testAllowHeaderAllowed()
     {
         $crawler = $this->call('POST', 'web/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-1, x-custom-2',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
@@ -180,7 +180,7 @@ class GlobalMiddlewareTest extends TestCase
         $this->app['config']->set('cors.allowed_headers', ['*']);
 
         $crawler = $this->call('POST', 'web/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
@@ -192,7 +192,7 @@ class GlobalMiddlewareTest extends TestCase
     public function testAllowHeaderNotAllowed()
     {
         $crawler = $this->call('POST', 'web/ping', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
@@ -202,21 +202,21 @@ class GlobalMiddlewareTest extends TestCase
     public function testError()
     {
         $crawler = $this->call('POST', 'api/error', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(500, $crawler->getStatusCode());
     }
 
     public function testValidationException()
     {
         $crawler = $this->call('POST', 'api/validation', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
-        $this->assertEquals('localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(302, $crawler->getStatusCode());
     }
 
@@ -227,7 +227,7 @@ class GlobalMiddlewareTest extends TestCase
         $this->app['config']->set('cors.exposed_headers', true);
 
         $this->call('POST', 'api/validation', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
         ]);
     }
 
@@ -238,7 +238,7 @@ class GlobalMiddlewareTest extends TestCase
         $this->app['config']->set('cors.allowed_origins', true);
 
         $this->call('POST', 'api/validation', [], [], [], [
-            'HTTP_ORIGIN' => 'localhost',
+            'HTTP_ORIGIN' => 'http://localhost',
         ]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $app['config']['cors'] = [
             'paths' => ['api/*'],
             'supports_credentials' => false,
-            'allowed_origins' => ['localhost'],
+            'allowed_origins' => ['http://localhost'],
             'allowed_headers' => ['X-Custom-1', 'X-Custom-2'],
             'allowed_methods' => ['GET', 'POST'],
             'exposed_headers' => [],


### PR DESCRIPTION
The Origin header always contains the scheme, and the allowed_origins configuration must also contain the scheme (unless you use a wildcard). Update the docs and tests to make this clear.