### PR TITLE
Use short array syntax for default config values in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,11 +73,11 @@ php artisan vendor:publish --tag="cors"
 
 | Option                   | Description                                                              | Default value |
 |--------------------------|--------------------------------------------------------------------------|---------------|
-| paths                    | You can enable CORS for 1 or multiple paths, eg. `['api/*'] `            | `array()`     |
-| allowed_origins          | Matches the request origin. Wildcards can be used, eg. `*.mydomain.com`  | `array('*')`  |
-| allowed_origins_patterns | Matches the request origin with `preg_match`.                            | `array()`     |
-| allowed_methods          | Matches the request method.                                              | `array('*')`  |
-| allowed_headers          | Sets the Access-Control-Allow-Headers response header.                   | `array('*')`  |
+| paths                    | You can enable CORS for 1 or multiple paths, eg. `['api/*'] `            | `[]`          |
+| allowed_origins          | Matches the request origin. Wildcards can be used, eg. `*.mydomain.com`  | `['*']`       |
+| allowed_origins_patterns | Matches the request origin with `preg_match`.                            | `[]`          |
+| allowed_methods          | Matches the request method.                                              | `['*']`       |
+| allowed_headers          | Sets the Access-Control-Allow-Headers response header.                   | `['*']`       |
 | exposed_headers          | Sets the Access-Control-Expose-Headers response header.                  | `false`       |
 | max_age                  | Sets the Access-Control-Max-Age response header.                         | `0`           |
 | supports_credentials     | Sets the Access-Control-Allow-Credentials header.                        | `false`       |


### PR DESCRIPTION
This aligns with the rest of the readme as well as the config file