### PR TITLE
Add test to cover nested wildcard

### DIFF
--- a/tests/GlobalMiddlewareTest.php
+++ b/tests/GlobalMiddlewareTest.php
@@ -70,6 +70,19 @@ class GlobalMiddlewareTest extends TestCase
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
+    public function testOriginsWildcardIncludesNestedSubdomains()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://api.service.test.laravel.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://api.service.test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
     public function testAllowAllOriginsWildcardNoMatch()
     {
         $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);


### PR DESCRIPTION
I recently wanted to use nested wildcard on `allowed_origins` and I wasn't sure whether it would work or not. I tested it and it seems to work as expected, however I noticed that there was no test covering this. If this is an acceptable feature, it would be safer to have a dedicated test for this so that if there's any refactoring in the future, it won't break this type of usage.