### PR TITLE
Enable PHP 8 builds

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2]
+        php: [8.0, 7.4, 7.3, 7.2]
         laravel: [^8, ^7, ^6]
         dependency-version: [prefer-stable]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "laravel/framework": "^6|^7|^8",
-        "phpunit/phpunit": "^6|^7|^8",
+        "phpunit/phpunit": "^6|^7|^8|^9",
         "squizlabs/php_codesniffer": "^3.5",
         "orchestra/testbench-dusk": "^4|^5|^6"
     },


### PR DESCRIPTION
PHP 8 is almost upon us so we should make sure laravel-cors runs properly on it in Github Actions.

In draft until https://github.com/asm89/stack-cors/pull/83 is merged.