### PR TITLE
Support Laravel Octane

### DIFF
--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
 use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Support\Facades\Config;
 
 class CorsServiceProvider extends BaseServiceProvider
 {
@@ -19,8 +20,8 @@ class CorsServiceProvider extends BaseServiceProvider
     {
         $this->mergeConfigFrom($this->configPath(), 'cors');
 
-        $this->app->singleton(CorsService::class, function ($app) {
-            return new CorsService($this->corsOptions(), $app);
+        $this->app->singleton(CorsService::class, function () {
+            return new CorsService($this->corsOptions());
         });
     }
 
@@ -61,7 +62,7 @@ class CorsServiceProvider extends BaseServiceProvider
      */
     protected function corsOptions()
     {
-        $config = $this->app['config']->get('cors');
+        $config = Config::get('cors');
 
         if ($config['exposed_headers'] && !is_array($config['exposed_headers'])) {
             throw new \RuntimeException('CORS config `exposed_headers` should be `false` or an array');

--- a/src/HandleCors.php
+++ b/src/HandleCors.php
@@ -8,6 +8,8 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
 use Symfony\Component\HttpFoundation\Response;
 
 class HandleCors
@@ -82,7 +84,7 @@ class HandleCors
      */
     public function onRequestHandled(RequestHandled $event)
     {
-        if ($this->shouldRun($event->request) && $this->container->make(Kernel::class)->hasMiddleware(static::class)) {
+        if ($this->shouldRun($event->request) && App::make(Kernel::class)->hasMiddleware(static::class)) {
             $this->addHeaders($event->request, $event->response);
         }
     }
@@ -131,7 +133,7 @@ class HandleCors
      */
     protected function getPathsByHost(string $host)
     {
-        $paths = $this->container['config']->get('cors.paths', []);
+        $paths = Config::get('cors.paths', []);
         // If where are paths by given host
         if (isset($paths[$host])) {
             return $paths[$host];


### PR DESCRIPTION
This PR aims to support Laravel Octane by avoiding the injection of the IoC container.

The container instance injected in the class `HandleCors` is not removed in this PR to avoid potential breaking changes, however the injected instance won't be called in `HandleCors`.

Facades are used instead as they always resolve up-to-date instances out of the latest version of the container.