### PR TITLE
Use fruitcake/php-cors instead of asm89/stack-cors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,7 @@
         "php": ">=7.2",
         "illuminate/support": "^6|^7|^8|^9",
         "illuminate/contracts": "^6|^7|^8|^9",
-        "symfony/http-foundation": "^4|^5|^6",
-        "symfony/http-kernel": "^4.3.4|^5|^6",
-        "asm89/stack-cors": "^2.0.1"
+        "fruitcake/php-cors": "^1"
     },
     "require-dev": {
         "laravel/framework": "^6|^7.24|^8",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7.2",
         "illuminate/support": "^6|^7|^8|^9",
         "illuminate/contracts": "^6|^7|^8|^9",
-        "fruitcake/php-cors": "^1"
+        "fruitcake/php-cors": "^0.1|^1"
     },
     "require-dev": {
         "laravel/framework": "^6|^7.24|^8",
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         },
         "laravel": {
             "providers": [

--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -20,7 +20,7 @@ class CorsServiceProvider extends BaseServiceProvider
         $this->mergeConfigFrom($this->configPath(), 'cors');
 
         $this->app->singleton(CorsService::class, function ($app) {
-            return new CorsService($this->corsOptions(), $app);
+            return new CorsService($this->app['config']->get('cors'));
         });
     }
 
@@ -52,64 +52,5 @@ class CorsServiceProvider extends BaseServiceProvider
     protected function configPath()
     {
         return __DIR__ . '/../config/cors.php';
-    }
-
-    /**
-     * Get options for CorsService
-     *
-     * @return array
-     */
-    protected function corsOptions()
-    {
-        $config = $this->app['config']->get('cors');
-
-        if ($config['exposed_headers'] && !is_array($config['exposed_headers'])) {
-            throw new \RuntimeException('CORS config `exposed_headers` should be `false` or an array');
-        }
-
-        foreach (['allowed_origins', 'allowed_origins_patterns',  'allowed_headers', 'allowed_methods'] as $key) {
-            if (!is_array($config[$key])) {
-                throw new \RuntimeException('CORS config `' . $key . '` should be an array');
-            }
-        }
-
-        // Convert case to supported options
-        $options = [
-            'supportsCredentials' => $config['supports_credentials'],
-            'allowedOrigins' => $config['allowed_origins'],
-            'allowedOriginsPatterns' => $config['allowed_origins_patterns'],
-            'allowedHeaders' => $config['allowed_headers'],
-            'allowedMethods' => $config['allowed_methods'],
-            'exposedHeaders' => $config['exposed_headers'],
-            'maxAge' => $config['max_age'],
-        ];
-
-        // Transform wildcard pattern
-        foreach ($options['allowedOrigins'] as $origin) {
-            if (strpos($origin, '*') !== false) {
-                $options['allowedOriginsPatterns'][] = $this->convertWildcardToPattern($origin);
-            }
-        }
-
-        return $options;
-    }
-
-    /**
-     * Create a pattern for a wildcard, based on Str::is() from Laravel
-     *
-     * @see https://github.com/laravel/framework/blob/5.5/src/Illuminate/Support/Str.php
-     * @param string $pattern
-     * @return string
-     */
-    protected function convertWildcardToPattern($pattern)
-    {
-        $pattern = preg_quote($pattern, '#');
-
-        // Asterisks are translated into zero-or-more regular expression wildcards
-        // to make it convenient to check if the strings starts with the given
-        // pattern such as "library/*", making any string check convenient.
-        $pattern = str_replace('\*', '.*', $pattern);
-
-        return '#^' . $pattern . '\z#u';
     }
 }

--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Fruitcake\Cors;
 
-use Asm89\Stack\CorsService;
+use Fruitcake\Cors\CorsService;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;

--- a/src/HandleCors.php
+++ b/src/HandleCors.php
@@ -3,7 +3,7 @@
 namespace Fruitcake\Cors;
 
 use Closure;
-use Asm89\Stack\CorsService;
+use Fruitcake\Cors\CorsService;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Http\Request;


### PR DESCRIPTION
Use https://github.com/fruitcake/php-cors (split from asm89/stack-cors)

Removes dependency on HttpKernel + 100% own control.

Move option normalisation to php-cors