### PR TITLE
Update README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,9 +78,9 @@ php artisan vendor:publish --tag="cors"
 | Option                   | Description                                                              | Default value |
 |--------------------------|--------------------------------------------------------------------------|---------------|
 | paths                    | You can enable CORS for 1 or multiple paths, eg. `['api/*'] `            | `[]`          |
+| allowed_methods          | Matches the request method.                                              | `['*']`       |
 | allowed_origins          | Matches the request origin. Wildcards can be used, eg. `*.mydomain.com` or `mydomain.com:*`  | `['*']`       |
 | allowed_origins_patterns | Matches the request origin with `preg_match`.                            | `[]`          |
-| allowed_methods          | Matches the request method.                                              | `['*']`       |
 | allowed_headers          | Sets the Access-Control-Allow-Headers response header.                   | `['*']`       |
 | exposed_headers          | Sets the Access-Control-Expose-Headers response header.                  | `false`       |
 | max_age                  | Sets the Access-Control-Max-Age response header.                         | `0`           |

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ php artisan vendor:publish --tag="cors"
 | allowed_origins          | Matches the request origin. Wildcards can be used, eg. `*.mydomain.com` or `mydomain.com:*`  | `['*']`       |
 | allowed_origins_patterns | Matches the request origin with `preg_match`.                            | `[]`          |
 | allowed_headers          | Sets the Access-Control-Allow-Headers response header.                   | `['*']`       |
-| exposed_headers          | Sets the Access-Control-Expose-Headers response header.                  | `false`       |
+| exposed_headers          | Sets the Access-Control-Expose-Headers response header.                  | `[]`       |
 | max_age                  | Sets the Access-Control-Max-Age response header.                         | `0`           |
 | supports_credentials     | Sets the Access-Control-Allow-Credentials header.                        | `false`       |
 


### PR DESCRIPTION
Based on the [config/cors.php](https://github.com/fruitcake/laravel-cors/blob/master/config/cors.php), we can update like below.

- Match the line order to config/cors.php.
  - "allowed_methods" should come right after "paths".
- Fix default value.
  - Default value of exposed_headers is `[]`.